### PR TITLE
Basic error handling and retry options

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    google_places (0.0.3)
+    google_places (0.0.5)
       httparty
 
 GEM

--- a/google_places.gemspec
+++ b/google_places.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "google_places"
-  s.version     = '0.0.4'
+  s.version     = '0.0.5'
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Marcel de Graaf"]
   s.email       = ["mail@marceldegraaf.net"]

--- a/lib/google_places.rb
+++ b/lib/google_places.rb
@@ -2,6 +2,6 @@ require 'rubygems'
 require 'httparty'
 
 
-%w(client location request spot).each do |file|
+%w(client location request spot error).each do |file|
   require File.join(File.dirname(__FILE__), 'google_places', file)
 end

--- a/lib/google_places/error.rb
+++ b/lib/google_places/error.rb
@@ -1,0 +1,16 @@
+module GooglePlaces
+  class OverQueryLimitError < HTTParty::ResponseError
+  end
+
+  class RequestDeniedError < HTTParty::ResponseError
+  end
+
+  class InvalidRequestError < HTTParty::ResponseError
+  end
+
+  class RetryError < HTTParty::ResponseError
+  end
+
+  class RetryTimeoutError < HTTParty::ResponseError
+  end
+end

--- a/lib/google_places/request.rb
+++ b/lib/google_places/request.rb
@@ -21,11 +21,54 @@ module GooglePlaces
     end
 
     def initialize(url, options)
+      retry_options = options.delete(:retry_options) || {}
+
+      retry_options[:status] ||= []
+      retry_options[:max]    ||= 0
+      retry_options[:delay]  ||= 5
+
+      retry_options[:status] = [retry_options[:status]] unless retry_options[:status].is_a?(Array)
+
       @response = self.class.get(url, :query => options)
+
+      return unless retry_options[:max] > 0 && retry_options[:status].include?(@response.parsed_response['status'])
+
+      retry_request = proc do
+        for i in (1..retry_options[:max])
+          sleep(retry_options[:delay])
+
+          @response = self.class.get(url, :query => options)
+
+          break unless retry_options[:status].include?(@response.parsed_response['status'])
+        end
+      end
+
+      if retry_options[:timeout]
+        begin
+          Timeout::timeout(retry_options[:timeout]) do
+            retry_request.call
+          end
+        rescue Timeout::Error
+          raise RetryTimeoutError.new(@response)
+        end
+      else
+        retry_request.call
+
+        raise RetryError.new(@response) if retry_options[:status].include?(@response.parsed_response['status'])
+      end
     end
 
     def parsed_response
-      @response.parsed_response
+      case @response.parsed_response['status']
+      when 'OK', 'ZERO_RESULTS'
+        @response.parsed_response
+      when 'OVER_QUERY_LIMIT'
+        raise OverQueryLimitError.new(@response)
+      when 'REQUEST_DENIED'
+        raise RequestDeniedError.new(@response)
+      when 'INVALID_REQUEST'
+        raise InvalidRequestError.new(@response)
+      end
     end
 
   end

--- a/lib/google_places/spot.rb
+++ b/lib/google_places/spot.rb
@@ -11,6 +11,7 @@ module GooglePlaces
       language  = options.delete(:language)
       location = Location.new(lat, lng)
       exclude = options.delete(:exclude) || []
+      retry_options = options.delete(:retry_options) || {}
 
       exclude = [exclude] unless exclude.is_a?(Array)
 
@@ -21,7 +22,8 @@ module GooglePlaces
         :key => api_key,
         :name => name,
         :language => language,
-        :keyword => keyword
+        :keyword => keyword,
+        :retry_options => retry_options
       }
 
       # Accept Types as a string or array
@@ -39,12 +41,14 @@ module GooglePlaces
     def self.find(reference, api_key, options = {})
       sensor = options.delete(:sensor) || false
       language  = options.delete(:language)
+      retry_options = options.delete(:retry_options) || {}
 
       response = Request.spot(
         :reference => reference,
         :sensor => sensor,
         :key => api_key,
-        :language => language
+        :language => language,
+        :retry_options => retry_options
       )
 
       self.new(response['result'])

--- a/spec/google_places/request_spec.rb
+++ b/spec/google_places/request_spec.rb
@@ -12,29 +12,155 @@ describe GooglePlaces::Request do
   context 'Listing spots' do
     use_vcr_cassette 'list_spots'
 
-    it 'should retrieve a list of spots' do
-      response = GooglePlaces::Request.spots(
-        :location => @location,
-        :radius => @radius,
-        :sensor => @sensor,
-        :key => api_key
-      )
+    context 'with valid options' do
+      it 'should retrieve a list of spots' do
+        response = GooglePlaces::Request.spots(
+          :location => @location,
+          :radius => @radius,
+          :sensor => @sensor,
+          :key => api_key
+        )
 
-      response['results'].should_not be_empty
+        response['results'].should_not be_empty
+      end
+    end
+
+    context 'with missing sensor' do
+      it do
+        lambda {
+          GooglePlaces::Request.spots(
+            :location => @location,
+            :radius => @radius,
+            :key => api_key
+          )
+        }.should raise_error GooglePlaces::RequestDeniedError
+      end
+    end
+
+    context 'without location' do
+      context 'without retry options' do
+        it do
+          lambda {
+            GooglePlaces::Request.spots(
+              :radius => @radius,
+              :sensor => @sensor,
+              :key => api_key
+            )
+          }.should raise_error GooglePlaces::InvalidRequestError
+        end
+      end
+
+      context 'with retry options' do
+        context 'without timeout' do
+          it do
+            lambda {
+              GooglePlaces::Request.spots(
+                :radius => @radius,
+                :sensor => @sensor,
+                :key => api_key,
+                :retry_options => {
+                  :max => 3,
+                  :status => 'INVALID_REQUEST',
+                  :delay => 1
+                }
+              )
+            }.should raise_error GooglePlaces::RetryError
+          end
+        end
+
+        context 'with timeout' do
+          it do
+            lambda {
+              GooglePlaces::Request.spots(
+                :radius => @radius,
+                :sensor => @sensor,
+                :key => api_key,
+                :retry_options => {
+                  :max => 3,
+                  :status => 'INVALID_REQUEST',
+                  :delay => 10,
+                  :timeout => 1
+                }
+              )
+            }.should raise_error GooglePlaces::RetryTimeoutError
+          end
+        end
+      end
     end
   end
 
   context 'Spot details' do
     use_vcr_cassette 'single_spot'
 
-    it 'should retrieve a single spot' do
-      response = GooglePlaces::Request.spot(
-        :reference => @reference,
-        :sensor => @sensor,
-        :key => api_key
-      )
+    context 'with valid options' do
+      it 'should retrieve a single spot' do
+        response = GooglePlaces::Request.spot(
+          :reference => @reference,
+          :sensor => @sensor,
+          :key => api_key
+        )
 
-      response['result'].should_not be_empty
+        response['result'].should_not be_empty
+      end
+    end
+
+    context 'with missing sensor' do
+      it do
+        lambda {
+          GooglePlaces::Request.spot(
+            :reference => @reference,
+            :key => api_key
+          )
+        }.should raise_error GooglePlaces::RequestDeniedError
+      end
+    end
+
+    context 'with missing reference' do
+      context 'without retry options' do
+        it do
+          lambda {
+            GooglePlaces::Request.spot(
+              :sensor => @sensor,
+              :key => api_key
+            )
+          }.should raise_error GooglePlaces::InvalidRequestError
+        end
+      end
+
+      context 'with retry options' do
+        context 'without timeout' do
+          it do
+            lambda {
+              GooglePlaces::Request.spot(
+                :sensor => @sensor,
+                :key => api_key,
+                :retry_options => {
+                  :max => 3,
+                  :status => 'INVALID_REQUEST',
+                  :delay => 1
+                }
+              )
+            }.should raise_error GooglePlaces::RetryError
+          end
+        end
+
+        context 'with timeout' do
+          it do
+            lambda {
+              GooglePlaces::Request.spot(
+                :sensor => @sensor,
+                :key => api_key,
+                :retry_options => {
+                  :max => 3,
+                  :status => 'INVALID_REQUEST',
+                  :delay => 10,
+                  :timeout => 1
+                }
+              )
+            }.should raise_error GooglePlaces::RetryTimeoutError
+          end
+        end
+      end
     end
   end
 

--- a/spec/google_places/spot_spec.rb
+++ b/spec/google_places/spot_spec.rb
@@ -44,7 +44,7 @@ describe GooglePlaces::Spot do
 
       it 'should have Spots with specific types' do
         @collection.each do |spot|
-          spot.types.should include('establishment')
+          (spot.types & ['food', 'establishment']).should be_any
         end
       end
     end
@@ -88,7 +88,7 @@ describe GooglePlaces::Spot do
 
       it 'should have Spots with specific types' do
         @collection.each do |spot|
-          spot.types.should include('establishment')
+          (spot.types & ['food', 'establishment']).should be_any
         end
       end
     end


### PR DESCRIPTION
As stated in https://github.com/marceldegraaf/google_places/issues/11, I hacked the gem in order to translate google places errors to exceptions and to implement some basic retry feature.

Except OVER_QUERY_LIMIT errors, all other changes have been spec'ed.

(Maybe it would be a good thing to mock HTTPParty in order to make easier the tests against Google Places, especially for OVER_QUERY_LIMIT errors)
