### PR TITLE
Add UnknownError exception

### DIFF
--- a/lib/google_places/error.rb
+++ b/lib/google_places/error.rb
@@ -13,4 +13,7 @@ module GooglePlaces
 
   class RetryTimeoutError < HTTParty::ResponseError
   end
+
+  class UnknownError < HTTParty::ResponseError
+  end
 end

--- a/lib/google_places/request.rb
+++ b/lib/google_places/request.rb
@@ -68,6 +68,8 @@ module GooglePlaces
         raise RequestDeniedError.new(@response)
       when 'INVALID_REQUEST'
         raise InvalidRequestError.new(@response)
+      when 'UNKNOWN_ERROR'
+        raise UnknownError.new(@response)
       end
     end
 


### PR DESCRIPTION
Google Places may fail when details for a specific place are fetched. As a result, it returns an empty result set with the status 'UNKNOWN_ERROR' (http://code.google.com/apis/maps/doc umentation/places/#PlaceDetailsStatusCodes). This pull request improves the gem in order to be able to throw an UnknownError exception when such case happens.
