### PR TITLE
Float to String Conversion 

### DIFF
--- a/lib/google_places/location.rb
+++ b/lib/google_places/location.rb
@@ -1,8 +1,8 @@
 module GooglePlaces
   class Location
     def initialize(lat, lng)
-      @lat = lat
-      @lng = lng
+      @lat = ("%.8f"%lat)
+      @lng = ("%.8f"%lng)
     end
 
     def format


### PR DESCRIPTION
If a user sends certain location data, it could be converted into scientific notation by Ruby. This will cause Google to throw an error.

An example being "-0.00006560" => -6.56e-05 

I believe this is a valid fix. It's my first pull request, so take it with a grain of salt. 

Thanks!
