### PR TITLE
Fix Ruby-1.8 incompatibility 

### DIFF
--- a/lib/google_places/spot.rb
+++ b/lib/google_places/spot.rb
@@ -226,9 +226,9 @@ module GooglePlaces
         next_page = false
         unless response["next_page_token"].nil?
           options = {
-            pagetoken: response["next_page_token"],
-            key: options[:key],
-            sensor: options[:sensor]
+            :pagetoken => response["next_page_token"],
+            :key => options[:key],
+            :sensor => options[:sensor]
           }
           sleep(2) # the time the token is issued, else InvalidRequestError
           next_page = true


### PR DESCRIPTION
Replaced some Ruby-1.9 style Hash syntax with 1.8 style hash rockets to maintain backward compatibility.
