### PR TITLE
Paginate results with next page token

### DIFF
--- a/lib/google_places/client.rb
+++ b/lib/google_places/client.rb
@@ -161,5 +161,23 @@ module GooglePlaces
     def spots_by_query(query, options = {})
       Spot.list_by_query(query, @api_key, @sensor, @options.merge(options))
     end
+
+    # Search for Spots with a pagetoken
+    #
+    # @return [Array<Spot>]
+    # @param [String] pagetoken the next page token to search for
+    # @param [Hash] options
+    # @option options [String,Array<String>] :exclude ([])
+    #   A String or an Array of <b>types</b> to exclude from results
+    # @option options [Hash] :retry_options ({})
+    #   A Hash containing parameters for search retries
+    # @option options [Object] :retry_options[:status] ([])
+    # @option options [Integer] :retry_options[:max] (0) the maximum retries
+    # @option options [Integer] :retry_options[:delay] (5) the delay between each retry in seconds
+    #
+    # @see https://developers.google.com/maps/documentation/places/supported_types List of supported types
+    def spots_by_pagetoken(pagetoken, options = {})
+      Spot.list_by_pagetoken(pagetoken, @api_key, @sensor, @options.merge(options))
+    end
   end
 end

--- a/lib/google_places/request.rb
+++ b/lib/google_places/request.rb
@@ -11,6 +11,7 @@ module GooglePlaces
     NEARBY_SEARCH_URL = 'https://maps.googleapis.com/maps/api/place/nearbysearch/json'
     DETAILS_URL       = 'https://maps.googleapis.com/maps/api/place/details/json'
     TEXT_SEARCH_URL   = 'https://maps.googleapis.com/maps/api/place/textsearch/json'
+    PAGETOKEN_URL     = 'https://maps.googleapis.com/maps/api/place/search/json'
 
     # Search for Spots at the provided location
     #
@@ -118,6 +119,26 @@ module GooglePlaces
     # @see https://developers.google.com/maps/documentation/places/supported_types List of supported types
     def self.spots_by_query(options = {})
       request = new(TEXT_SEARCH_URL, options)
+      request.parsed_response
+    end
+
+    # Search for Spots with a page token
+    #
+    # @return [Array<Spot>]
+    # @param [String] pagetoken the next page token to search for
+    # @param [String] api_key the provided api key
+    # @param [Hash] options
+    # @option options [String,Array<String>] :exclude ([])
+    #   A String or an Array of <b>types</b> to exclude from results
+    # @option options [Hash] :retry_options ({})
+    #   A Hash containing parameters for search retries
+    # @option options [Object] :retry_options[:status] ([])
+    # @option options [Integer] :retry_options[:max] (0) the maximum retries
+    # @option options [Integer] :retry_options[:delay] (5) the delay between each retry in seconds
+    #
+    # @see https://developers.google.com/maps/documentation/places/supported_types List of supported types
+    def self.spots_by_pagetoken(options = {})
+      request = new(PAGETOKEN_URL, options)
       request.parsed_response
     end
 

--- a/spec/google_places/spot_spec.rb
+++ b/spec/google_places/spot_spec.rb
@@ -8,6 +8,7 @@ describe GooglePlaces::Spot do
     @radius = 200
     @sensor = false
     @reference = "CnRsAAAASc4grenwL0h3X5VPNp5fkDNfqbjt3iQtWIPlKS-3ms9GbnCxR_FLHO0B0ZKCgJSg19qymkeHagjQFB4aUL87yhp4mhFTc17DopK1oiYDaeGthztSjERic8TmFNe-6zOpKSdiZWKE6xlQvcbSiWIJchIQOEYZqunSSZqNDoBSs77bWRoUJcMMVANtSlhy0llKI0MI6VcC7DU"
+    @pagetoken = "CmRVAAAAqKK43TjXKnyEx4-XTWd4bC-iBq88Olspwga_JQbEpznYpfwXYbWBrxmb-1QYD4DMtq8gym5YruCEVjByOlKn8PWKQO5fHvuYD8rWKHUeBvMleM7k3oh9TUG8zqcyuhPmEhCG_C2XuypmkQ20hRvxro4sGhQN3nbWCjgpjyG_E_ayjVIoTGbViw"
   end
 
   context 'List spots' do
@@ -151,11 +152,21 @@ describe GooglePlaces::Spot do
       @collection.should have_at_most(20).places
     end
 
-
     it 'should return at most 20 results when :multipage is not present' do
       @collection = GooglePlaces::Spot.list_by_query("wolfgang", api_key, @sensor, :lat => "40.808235", :lng => "-73.948733", :radius => @radius)
       @collection.should have_at_most(20).places
     end
+
+    it 'should return a pagetoken when there is more than 20 results and :multipage is false' do
+      @collection = GooglePlaces::Spot.list_by_query("wolfgang", api_key, @sensor, :lat => "40.808235", :lng => "-73.948733", :radius => @radius, :multipage => false)
+      @collection.last.nextpagetoken.should_not be_nil
+    end
+
+    it 'should return some results when :pagetoken is present' do
+      @collection = GooglePlaces::Spot.list_by_pagetoken(@pagetoken, api_key, @sensor)
+      @collection.should have_at_least(1).places
+    end
+
   end
 
   context 'List spots by query' do


### PR DESCRIPTION
Some changes to get the next page token and use it to retrieve next results.

When the multipage_request flag is turned off (default), we get 20 results per request and the next page token. So I added a "nextpagetoken" attribute to the last result and we can now use it to load the next page.
