### PR TITLE
Handle NOT_FOUND status for Spot requests

### DIFF
--- a/lib/google_places/error.rb
+++ b/lib/google_places/error.rb
@@ -28,4 +28,7 @@ module GooglePlaces
 
   class UnknownError < HTTParty::ResponseError
   end
+
+  class NotFoundError < HTTParty::ResponseError
+  end
 end

--- a/lib/google_places/request.rb
+++ b/lib/google_places/request.rb
@@ -232,6 +232,7 @@ module GooglePlaces
     # @raise [RequestDeniedError] when server response object includes 'REQUEST_DENIED'
     # @raise [InvalidRequestError] when server response object includes 'INVALID_REQUEST'
     # @raise [UnknownError] when server response object includes 'UNKNOWN_ERROR'
+    # @raise [NotFoundError] when server response object includes 'NOT_FOUND'
     # @return [String] the response from the server as JSON
     def parsed_response
       case @response.parsed_response['status']
@@ -245,6 +246,8 @@ module GooglePlaces
         raise InvalidRequestError.new(@response)
       when 'UNKNOWN_ERROR'
         raise UnknownError.new(@response)
+      when 'NOT_FOUND'
+        raise NotFoundError.new(@response)
       end
     end
 

--- a/spec/google_places/request_spec.rb
+++ b/spec/google_places/request_spec.rb
@@ -8,6 +8,7 @@ describe GooglePlaces::Request do
     @radius = 200
     @sensor = false
     @reference = "CnRsAAAASc4grenwL0h3X5VPNp5fkDNfqbjt3iQtWIPlKS-3ms9GbnCxR_FLHO0B0ZKCgJSg19qymkeHagjQFB4aUL87yhp4mhFTc17DopK1oiYDaeGthztSjERic8TmFNe-6zOpKSdiZWKE6xlQvcbSiWIJchIQOEYZqunSSZqNDoBSs77bWRoUJcMMVANtSlhy0llKI0MI6VcC7DU"
+    @reference_not_found = "CnRpAAAAlO2WvF_4eOqp02TAWKsXpPSCFz8KxBjraWhB4MSvdUPqXN0yCpxQgblam1LeRENcWZF-9-2CEfUwlHUli61PaYe0e7dUPAU302tk6KkalnKqx7nv07iFA1Ca_Y1WoCLH9adEWwkxKMITlbGhUUz9-hIQPxQ4Bp_dz5nHloUFkj3rkBoUDSPqy2smqMnPEo4ayfbDupeKEZY"
   end
 
   context 'Listing spots' do
@@ -170,6 +171,17 @@ describe GooglePlaces::Request do
           :key => api_key
         )
         response['result'].should_not be_empty
+      end
+      context 'with reference not found' do
+        it 'should raise not found error' do
+          lambda {
+            GooglePlaces::Request.spot(
+              :reference => @reference_not_found,
+              :sensor => @sensor,
+              :key => api_key
+            )
+          }.should raise_error GooglePlaces::NotFoundError
+        end
       end
     end
     context 'with missing sensor' do


### PR DESCRIPTION
I occasionally run into instances where my place detail requests are returning NOT_FOUND using a saved reference. I wanted to rescue from these instances.

I'm not sure why the references no longer work. However, it seems i'm not the only one:

http://stackoverflow.com/questions/17203910/google-places-details-api-call-return-not-found-for-an-existing-autocomplete-ref
