### PR TITLE
Allow Spot attributes to be accessed using []

### DIFF
--- a/lib/google_places/spot.rb
+++ b/lib/google_places/spot.rb
@@ -311,6 +311,10 @@ module GooglePlaces
       @nextpagetoken              = json_result_object['nextpagetoken']
     end
 
+    def [] (key)
+      send(key)
+    end
+
     def address_component(address_component_type, address_component_length)
       if component = address_components_of_type(address_component_type)
         component.first[address_component_length] unless component.first.nil?

--- a/spec/google_places/spot_spec.rb
+++ b/spec/google_places/spot_spec.rb
@@ -194,6 +194,14 @@ describe GooglePlaces::Spot do
       it "should have the attribute: #{attribute}" do
         @spot.respond_to?(attribute).should == true
       end
+
+      it "should respond to ['#{attribute}']" do
+        expect { @spot[attribute] }.to_not raise_error
+      end
+
+      it "should respond to [:#{attribute}]" do
+        expect { @spot[attribute.to_sym] }.to_not raise_error
+      end
     end
     it 'should contain 5 reviews' do
       @spot.reviews.size == 5


### PR DESCRIPTION
This makes it easier to cache results and be indifferent to whether the object in hand is a Spot or Hash.
