### PR TITLE
Add :place_id attribute to Spot.

### DIFF
--- a/lib/google_places/spot.rb
+++ b/lib/google_places/spot.rb
@@ -2,7 +2,7 @@ require 'google_places/review'
 
 module GooglePlaces
   class Spot
-    attr_accessor :lat, :lng, :name, :icon, :reference, :vicinity, :types, :id, :formatted_phone_number, :international_phone_number, :formatted_address, :address_components, :street_number, :street, :city, :region, :postal_code, :country, :rating, :url, :cid, :website, :reviews, :aspects, :zagat_selected, :zagat_reviewed, :photos, :review_summary, :nextpagetoken, :price_level, :opening_hours, :events, :utc_offset
+    attr_accessor :lat, :lng, :name, :icon, :reference, :vicinity, :types, :id, :formatted_phone_number, :international_phone_number, :formatted_address, :address_components, :street_number, :street, :city, :region, :postal_code, :country, :rating, :url, :cid, :website, :reviews, :aspects, :zagat_selected, :zagat_reviewed, :photos, :review_summary, :nextpagetoken, :price_level, :opening_hours, :events, :utc_offset, :place_id
 
     # Search for Spots at the provided location
     #
@@ -27,7 +27,7 @@ module GooglePlaces
     #     the number of check-ins from your application, global popularity, and other factors.
     #   - distance. This option sorts results in ascending order by their distance from the specified location.
     #     Ranking results by distance will set a fixed search radius of 50km.
-    #     One or more of keyword, name, or types is required.                                                                                                                                                                                                                                                                                       distance. This option sorts results in ascending order by their distance from the specified location. Ranking results by distance will set a fixed search radius of 50km. One or more of keyword, name, or types is required.
+    #     One or more of keyword, name, or types is required.
     # @option options [String,Array] :types
     #   Restricts the results to Spots matching at least one of the specified types
     # @option options [String] :name
@@ -363,6 +363,7 @@ module GooglePlaces
     # @return [Spot] a newly created spot
     def initialize(json_result_object, api_key, sensor)
       @reference                  = json_result_object['reference']
+      @place_id                   = json_result_object['place_id']
       @vicinity                   = json_result_object['vicinity']
       @lat                        = json_result_object['geometry']['location']['lat']
       @lng                        = json_result_object['geometry']['location']['lng']

--- a/spec/google_places/spot_spec.rb
+++ b/spec/google_places/spot_spec.rb
@@ -203,7 +203,7 @@ describe GooglePlaces::Spot do
     it 'should be a Spot' do
       @spot.class.should == GooglePlaces::Spot
     end
-    %w(reference vicinity lat lng name icon types id formatted_phone_number international_phone_number formatted_address address_components street_number street city region postal_code country rating url types website price_level opening_hours events utc_offset).each do |attribute|
+    %w(reference vicinity lat lng name icon types id formatted_phone_number international_phone_number formatted_address address_components street_number street city region postal_code country rating url types website price_level opening_hours events utc_offset place_id).each do |attribute|
       it "should have the attribute: #{attribute}" do
         @spot.respond_to?(attribute).should == true
       end


### PR DESCRIPTION
Posted on Google Places API as of June 24, 2014:

Note: The id and reference fields are deprecated as of June 24, 2014. They are replaced by the new place ID, a unique identifier that can be used to compare places and to retrieve information about a place. The Places API currently returns a place_id in all responses, and accepts a place_id in the Place Details and Place Delete requests. Soon after June 24, 2015, the API will stop returning the id and reference fields in responses. Some time later, the API will no longer accept the reference in requests. We recommend that you update your code to use the new place_id instead of id and reference as soon as possible.
