### PR TITLE
Update gems, remove deprecated calls in tests, and remove bad tests.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,28 +7,38 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    diff-lcs (1.1.3)
-    fakeweb (1.3.0)
-    httparty (0.12.0)
+    addressable (2.3.6)
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
+    diff-lcs (1.2.5)
+    httparty (0.13.1)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     json (1.8.1)
     multi_xml (0.5.5)
-    rspec (2.11.0)
-      rspec-core (~> 2.11.0)
-      rspec-expectations (~> 2.11.0)
-      rspec-mocks (~> 2.11.0)
-    rspec-core (2.11.1)
-    rspec-expectations (2.11.3)
-      diff-lcs (~> 1.1.3)
-    rspec-mocks (2.11.3)
-    vcr (2.2.5)
+    rspec (3.0.0)
+      rspec-core (~> 3.0.0)
+      rspec-expectations (~> 3.0.0)
+      rspec-mocks (~> 3.0.0)
+    rspec-core (3.0.2)
+      rspec-support (~> 3.0.0)
+    rspec-expectations (3.0.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.0.0)
+    rspec-mocks (3.0.2)
+      rspec-support (~> 3.0.0)
+    rspec-support (3.0.2)
+    safe_yaml (1.0.3)
+    vcr (2.9.2)
+    webmock (1.18.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  fakeweb
   google_places!
   rspec
   vcr
+  webmock

--- a/google_places.gemspec
+++ b/google_places.gemspec
@@ -1,13 +1,13 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
+$:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
-  s.name        = "google_places"
+  s.name        = 'google_places'
   s.version     = '0.21.0'
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Marcel de Graaf"]
-  s.email       = ["mail@marceldegraaf.net"]
-  s.homepage    = "https://github.com/marceldegraaf/google_places"
+  s.authors     = ['Marcel de Graaf']
+  s.email       = ['mail@marceldegraaf.net']
+  s.homepage    = 'https://github.com/marceldegraaf/google_places'
   s.summary     = %q{A Ruby wrapper around the Google Places API.}
   s.description = %q{This gem provides a Ruby wrapper around the Google Places API for use in your own project. Please note that this gem does not provide OAuth authentication.}
   s.license     = 'MIT'
@@ -15,10 +15,10 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.require_paths = ["lib"]
+  s.require_paths = ['lib']
 
   s.add_dependency 'httparty'
   s.add_development_dependency 'rspec'
-  s.add_development_dependency 'fakeweb'
+  s.add_development_dependency 'webmock'
   s.add_development_dependency 'vcr'
 end

--- a/spec/google_places/client_spec.rb
+++ b/spec/google_places/client_spec.rb
@@ -4,39 +4,39 @@ describe GooglePlaces::Client do
 
   it 'should initialize with an api_key' do
     @client = GooglePlaces::Client.new(api_key)
-    @client.api_key.should == api_key
+    expect(@client.api_key).to eq(api_key)
   end
 
   it 'should request spots' do
     lat, lng = '-33.8670522', '151.1957362'
     @client = GooglePlaces::Client.new(api_key)
-    GooglePlaces::Spot.should_receive(:list).with(lat, lng, api_key, false, {})
+    expect(GooglePlaces::Spot).to receive(:list).with(lat, lng, api_key, false, {})
 
     @client.spots(lat, lng)
   end
 
   it 'should request a single spot' do
-    reference = "CoQBeAAAAO-prCRp9Atcj_rvavsLyv-DnxbGkw8QyRZb6Srm6QHOcww6lqFhIs2c7Ie6fMg3PZ4PhicfJL7ZWlaHaLDTqmRisoTQQUn61WTcSXAAiCOzcm0JDBnafqrskSpFtNUgzGAOx29WGnWSP44jmjtioIsJN9ik8yjK7UxP4buAmMPVEhBXPiCfHXk1CQ6XRuQhpztsGhQU4U6-tWjTHcLSVzjbNxoiuihbaA"
+    reference = 'CoQBeAAAAO-prCRp9Atcj_rvavsLyv-DnxbGkw8QyRZb6Srm6QHOcww6lqFhIs2c7Ie6fMg3PZ4PhicfJL7ZWlaHaLDTqmRisoTQQUn61WTcSXAAiCOzcm0JDBnafqrskSpFtNUgzGAOx29WGnWSP44jmjtioIsJN9ik8yjK7UxP4buAmMPVEhBXPiCfHXk1CQ6XRuQhpztsGhQU4U6-tWjTHcLSVzjbNxoiuihbaA'
     @client = GooglePlaces::Client.new(api_key)
-    GooglePlaces::Spot.should_receive(:find).with(reference, api_key, false, {})
+    expect(GooglePlaces::Spot).to receive(:find).with(reference, api_key, false, {})
 
     @client.spot(reference)
   end
 
   it 'should request spots by query' do
-    query = "Statue of liberty, New York"
+    query = 'Statue of liberty, New York'
     @client = GooglePlaces::Client.new(api_key)
-    GooglePlaces::Spot.should_receive(:list_by_query).with(query, api_key, false, {})
+    expect(GooglePlaces::Spot).to receive(:list_by_query).with(query, api_key, false, {})
 
     @client.spots_by_query(query)
   end
 
   it 'should request spots by radar' do
-    keywords = "landmarks"
+    keywords = 'landmarks'
     lat, lng = '51.511627', '-0.183778'
     radius = 5000
     @client = GooglePlaces::Client.new(api_key)
-    GooglePlaces::Spot.should_receive(:list_by_radar).with(lat, lng, api_key, false, {:radius=> radius, :keyword =>  keywords})
+    expect(GooglePlaces::Spot).to receive(:list_by_radar).with(lat, lng, api_key, false, {:radius=> radius, :keyword =>  keywords})
 
     @client.spots_by_radar(lat, lng, :radius => radius, :keyword =>  keywords)
   end

--- a/spec/google_places/location_spec.rb
+++ b/spec/google_places/location_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe GooglePlaces::Location do
 
   it 'should return a location based on a lat and lng' do
-    GooglePlaces::Location.new('123', '456').format.should == '123.00000000,456.00000000'
+    expect(GooglePlaces::Location.new('123', '456').format).to eq('123.00000000,456.00000000')
   end
 
 end

--- a/spec/google_places/photo_spec.rb
+++ b/spec/google_places/photo_spec.rb
@@ -8,22 +8,21 @@ describe GooglePlaces::Photo do
     @photo_reference = "CnRtAAAACQQXR83Jc3Pffxt1Zx7QbCe6AfY2negSNzkk2IeSf0q5nxHgartLzkr1fltSlkEDSS-EZqswWAW2eQDbiOl12J-V4Rmn_JNko9e9gSnMwxHBdmScu_84NMSe-0RwB9BM6AEqE8sENXQ8cpWaiEsC_RIQLzIJxpRdoqSPrPtrjTrOhxoUWb8uwObkV4duXfKIiNB20gfnu88"
   end
 
-  context 'Photo' do
-    use_vcr_cassette 'photo'
+  context 'Photo', vcr: { cassette_name: 'photo'} do
     before :each do
       @photo = GooglePlaces::Photo.new(400, 400, @photo_reference, [], api_key, @sensor)
     end
     it 'should be a Photo' do
-      @photo.class.should == GooglePlaces::Photo
+      expect(@photo.class).to eq(GooglePlaces::Photo)
     end
     %w(width height photo_reference html_attributions).each do |attribute|
       it "should have the attribute: #{attribute}" do
-        @photo.respond_to?(attribute).should == true
+        expect(@photo.respond_to?(attribute)).to eq(true)
       end
     end
     it 'should return a url when fetched' do
       url = @photo.fetch_url(@max_width)
-      url.should_not be_empty
+      expect(url).to_not be_empty
     end
   end
 end

--- a/spec/google_places/request_spec.rb
+++ b/spec/google_places/request_spec.rb
@@ -4,16 +4,15 @@ describe GooglePlaces::Request do
 
   before :each do
     @location = GooglePlaces::Location.new('-33.8670522', '151.1957362').format
-    @query = "Statue of liberty, New York"
+    @query = 'Statue of liberty, New York'
     @radius = 200
     @sensor = false
-    @reference = "CnRsAAAASc4grenwL0h3X5VPNp5fkDNfqbjt3iQtWIPlKS-3ms9GbnCxR_FLHO0B0ZKCgJSg19qymkeHagjQFB4aUL87yhp4mhFTc17DopK1oiYDaeGthztSjERic8TmFNe-6zOpKSdiZWKE6xlQvcbSiWIJchIQOEYZqunSSZqNDoBSs77bWRoUJcMMVANtSlhy0llKI0MI6VcC7DU"
-    @reference_not_found = "CnRpAAAAlO2WvF_4eOqp02TAWKsXpPSCFz8KxBjraWhB4MSvdUPqXN0yCpxQgblam1LeRENcWZF-9-2CEfUwlHUli61PaYe0e7dUPAU302tk6KkalnKqx7nv07iFA1Ca_Y1WoCLH9adEWwkxKMITlbGhUUz9-hIQPxQ4Bp_dz5nHloUFkj3rkBoUDSPqy2smqMnPEo4ayfbDupeKEZY"
-    @keyword = "attractions"
+    @reference = 'CnRsAAAASc4grenwL0h3X5VPNp5fkDNfqbjt3iQtWIPlKS-3ms9GbnCxR_FLHO0B0ZKCgJSg19qymkeHagjQFB4aUL87yhp4mhFTc17DopK1oiYDaeGthztSjERic8TmFNe-6zOpKSdiZWKE6xlQvcbSiWIJchIQOEYZqunSSZqNDoBSs77bWRoUJcMMVANtSlhy0llKI0MI6VcC7DU'
+    @reference_not_found = 'CnRpAAAAlO2WvF_4eOqp02TAWKsXpPSCFz8KxBjraWhB4MSvdUPqXN0yCpxQgblam1LeRENcWZF-9-2CEfUwlHUli61PaYe0e7dUPAU302tk6KkalnKqx7nv07iFA1Ca_Y1WoCLH9adEWwkxKMITlbGhUUz9-hIQPxQ4Bp_dz5nHloUFkj3rkBoUDSPqy2smqMnPEo4ayfbDupeKEZY'
+    @keyword = 'attractions'
   end
 
-  context 'Listing spots' do
-    use_vcr_cassette 'list_spots'
+  context 'Listing spots', vcr: { cassette_name: 'list_spots' } do
     context 'with valid options' do
       it 'should retrieve a list of spots' do
         response = GooglePlaces::Request.spots(
@@ -22,36 +21,25 @@ describe GooglePlaces::Request do
           :sensor => @sensor,
           :key => api_key
         )
-        response['results'].should_not be_empty
-      end
-    end
-    context 'with missing sensor' do
-      it do
-        lambda {
-          GooglePlaces::Request.spots(
-            :location => @location,
-            :radius => @radius,
-            :key => api_key
-          )
-        }.should raise_error GooglePlaces::RequestDeniedError
+        expect(response['results']).to_not be_empty
       end
     end
     context 'without location' do
       context 'without retry options' do
         it do
-          lambda {
+          expect(lambda {
             GooglePlaces::Request.spots(
               :radius => @radius,
               :sensor => @sensor,
               :key => api_key
             )
-          }.should raise_error GooglePlaces::InvalidRequestError
+          }).to raise_error GooglePlaces::InvalidRequestError
         end
       end
       context 'with retry options' do
         context 'without timeout' do
           it do
-            lambda {
+            expect(lambda {
               GooglePlaces::Request.spots(
                 :radius => @radius,
                 :sensor => @sensor,
@@ -62,12 +50,12 @@ describe GooglePlaces::Request do
                   :delay => 1
                 }
               )
-            }.should raise_error GooglePlaces::RetryError
+            }).to raise_error GooglePlaces::RetryError
           end
         end
         context 'with timeout' do
           it do
-            lambda {
+            expect(lambda {
               GooglePlaces::Request.spots(
                 :radius => @radius,
                 :sensor => @sensor,
@@ -79,7 +67,7 @@ describe GooglePlaces::Request do
                   :timeout => 1
                 }
               )
-            }.should raise_error GooglePlaces::RetryTimeoutError
+            }).to raise_error GooglePlaces::RetryTimeoutError
           end
         end
       end
@@ -87,8 +75,7 @@ describe GooglePlaces::Request do
   end
 
 
-  context 'Listing spots by query' do
-    use_vcr_cassette 'list_spots'
+  context 'Listing spots by query', vcr: { cassette_name: 'list_spots' } do
 
     context 'with valid options' do
       it 'should retrieve a list of spots' do
@@ -98,37 +85,26 @@ describe GooglePlaces::Request do
           :key => api_key
         )
 
-        response['results'].should_not be_empty
-      end
-    end
-
-    context 'with missing sensor' do
-      it do
-        lambda {
-          GooglePlaces::Request.spots_by_query(
-            :query => @query,
-            :key => api_key
-          )
-        }.should raise_error GooglePlaces::RequestDeniedError
+        expect(response['results']).to_not be_empty
       end
     end
 
     context 'without query' do
       context 'without retry options' do
         it do
-          lambda {
+          expect(lambda {
             GooglePlaces::Request.spots_by_query(
               :sensor => @sensor,
               :key => api_key
             )
-          }.should raise_error GooglePlaces::InvalidRequestError
+          }).to raise_error GooglePlaces::InvalidRequestError
         end
       end
 
       context 'with retry options' do
         context 'without timeout' do
           it do
-            lambda {
+            expect(lambda {
               GooglePlaces::Request.spots_by_query(
                 :sensor => @sensor,
                 :key => api_key,
@@ -138,13 +114,13 @@ describe GooglePlaces::Request do
                   :delay => 1
                 }
               )
-            }.should raise_error GooglePlaces::RetryError
+            }).to raise_error GooglePlaces::RetryError
           end
         end
 
         context 'with timeout' do
           it do
-            lambda {
+            expect(lambda {
               GooglePlaces::Request.spots_by_query(
                 :sensor => @sensor,
                 :key => api_key,
@@ -155,15 +131,14 @@ describe GooglePlaces::Request do
                   :timeout => 1
                 }
               )
-            }.should raise_error GooglePlaces::RetryTimeoutError
+            }).to raise_error GooglePlaces::RetryTimeoutError
           end
         end
       end
     end
   end
 
-  context 'Spot details' do
-    use_vcr_cassette 'single_spot'
+  context 'Spot details', vcr: { cassette_name: 'single_spot' } do
     context 'with valid options' do
       it 'should retrieve a single spot' do
         response = GooglePlaces::Request.spot(
@@ -171,45 +146,35 @@ describe GooglePlaces::Request do
           :sensor => @sensor,
           :key => api_key
         )
-        response['result'].should_not be_empty
+        expect(response['result']).to_not be_empty
       end
       context 'with reference not found' do
-        it 'should raise not found error' do
-          lambda {
+        it 'to raise not found error' do
+          expect(lambda {
             GooglePlaces::Request.spot(
               :reference => @reference_not_found,
               :sensor => @sensor,
               :key => api_key
             )
-          }.should raise_error GooglePlaces::NotFoundError
+          }).to raise_error GooglePlaces::NotFoundError
         end
-      end
-    end
-    context 'with missing sensor' do
-      it do
-        lambda {
-          GooglePlaces::Request.spot(
-            :reference => @reference,
-            :key => api_key
-          )
-        }.should raise_error GooglePlaces::RequestDeniedError
       end
     end
     context 'with missing reference' do
       context 'without retry options' do
         it do
-          lambda {
+          expect(lambda {
             GooglePlaces::Request.spot(
               :sensor => @sensor,
               :key => api_key
             )
-          }.should raise_error GooglePlaces::InvalidRequestError
+          }).to raise_error GooglePlaces::InvalidRequestError
         end
       end
       context 'with retry options' do
         context 'without timeout' do
           it do
-            lambda {
+            expect(lambda {
               GooglePlaces::Request.spot(
                 :sensor => @sensor,
                 :key => api_key,
@@ -219,12 +184,12 @@ describe GooglePlaces::Request do
                   :delay => 1
                 }
               )
-            }.should raise_error GooglePlaces::RetryError
+            }).to raise_error GooglePlaces::RetryError
           end
         end
         context 'with timeout' do
           it do
-            lambda {
+            expect(lambda {
               GooglePlaces::Request.spot(
                 :sensor => @sensor,
                 :key => api_key,
@@ -235,7 +200,7 @@ describe GooglePlaces::Request do
                   :timeout => 1
                 }
               )
-            }.should raise_error GooglePlaces::RetryTimeoutError
+            }).to raise_error GooglePlaces::RetryTimeoutError
           end
         end
       end
@@ -244,8 +209,7 @@ describe GooglePlaces::Request do
 
 
 
-  context 'Listing spots by radar' do
-    use_vcr_cassette 'list_spots_by_radar'
+  context 'Listing spots by radar', vcr: { cassette_name: 'list_spots_by_radar' } do
 
     context 'with valid options' do
       context 'with keyword' do
@@ -257,7 +221,7 @@ describe GooglePlaces::Request do
             :sensor => @sensor,
             :key => api_key
           ) 
-          response['results'].should_not be_empty
+          expect(response['results']).to_not be_empty
         end
       end
       
@@ -270,42 +234,29 @@ describe GooglePlaces::Request do
             :sensor => @sensor,
             :key => api_key
           )
-          response['results'].should_not be_empty
+          expect(response['results']).to_not be_empty
         end
-      end
-    end
-
-    context 'with missing sensor' do
-      it do
-        lambda {
-          GooglePlaces::Request.spots_by_radar(
-            :location => @location,
-            :keyword => @keyword,
-            :radius => @radius,
-            :key => api_key
-          )
-        }.should raise_error GooglePlaces::RequestDeniedError
       end
     end
 
    context 'without keyword' do
       context 'without retry options' do
         it do
-          lambda {
+          expect(lambda {
             GooglePlaces::Request.spots_by_radar(
               :location => @location,
               :radius => @radius,
               :sensor => @sensor,
               :key => api_key
             )
-          }.should raise_error GooglePlaces::InvalidRequestError
+          }).to raise_error GooglePlaces::InvalidRequestError
         end
       end
 
       context 'with retry options' do
         context 'without timeout' do
           it do
-            lambda {
+            expect(lambda {
               GooglePlaces::Request.spots_by_radar(
                 :location => @location,
                 :radius => @radius,
@@ -317,13 +268,13 @@ describe GooglePlaces::Request do
                   :delay => 1
                 }
               )
-            }.should raise_error GooglePlaces::RetryError
+            }).to raise_error GooglePlaces::RetryError
           end
         end
 
         context 'with timeout' do
           it do
-            lambda {
+            expect(lambda {
               GooglePlaces::Request.spots_by_radar(
                 :location => @location,
                 :radius => @radius,
@@ -336,7 +287,7 @@ describe GooglePlaces::Request do
                   :timeout => 1
                 }
               )
-            }.should raise_error GooglePlaces::RetryTimeoutError
+            }).to raise_error GooglePlaces::RetryTimeoutError
           end
         end
       end

--- a/spec/google_places/spot_spec.rb
+++ b/spec/google_places/spot_spec.rb
@@ -7,52 +7,45 @@ describe GooglePlaces::Spot do
     @lng = '151.1957362'
     @radius = 200
     @sensor = false
-    @reference = "CnRsAAAASc4grenwL0h3X5VPNp5fkDNfqbjt3iQtWIPlKS-3ms9GbnCxR_FLHO0B0ZKCgJSg19qymkeHagjQFB4aUL87yhp4mhFTc17DopK1oiYDaeGthztSjERic8TmFNe-6zOpKSdiZWKE6xlQvcbSiWIJchIQOEYZqunSSZqNDoBSs77bWRoUJcMMVANtSlhy0llKI0MI6VcC7DU"
-    @pagetoken = "CmRVAAAAqKK43TjXKnyEx4-XTWd4bC-iBq88Olspwga_JQbEpznYpfwXYbWBrxmb-1QYD4DMtq8gym5YruCEVjByOlKn8PWKQO5fHvuYD8rWKHUeBvMleM7k3oh9TUG8zqcyuhPmEhCG_C2XuypmkQ20hRvxro4sGhQN3nbWCjgpjyG_E_ayjVIoTGbViw"
+    @reference = 'CnRsAAAASc4grenwL0h3X5VPNp5fkDNfqbjt3iQtWIPlKS-3ms9GbnCxR_FLHO0B0ZKCgJSg19qymkeHagjQFB4aUL87yhp4mhFTc17DopK1oiYDaeGthztSjERic8TmFNe-6zOpKSdiZWKE6xlQvcbSiWIJchIQOEYZqunSSZqNDoBSs77bWRoUJcMMVANtSlhy0llKI0MI6VcC7DU'
+    @pagetoken = 'CmRVAAAAqKK43TjXKnyEx4-XTWd4bC-iBq88Olspwga_JQbEpznYpfwXYbWBrxmb-1QYD4DMtq8gym5YruCEVjByOlKn8PWKQO5fHvuYD8rWKHUeBvMleM7k3oh9TUG8zqcyuhPmEhCG_C2XuypmkQ20hRvxro4sGhQN3nbWCjgpjyG_E_ayjVIoTGbViw'
   end
 
-  context 'List spots' do
-    use_vcr_cassette 'list_spots'
+  context 'List spots', vcr: { cassette_name: 'list_spots' } do
 
     after(:each) do
-      @collection.map(&:class).uniq.should == [GooglePlaces::Spot]
+      expect(@collection.map(&:class).uniq).to eq [GooglePlaces::Spot]
     end
 
     it 'should be a collection of Spots' do
       @collection = GooglePlaces::Spot.list(@lat, @lng, api_key, @sensor, :radius => @radius)
     end
 
-    describe 'with a single type' do
-      use_vcr_cassette 'list_spots_with_single_type'
-
+    describe 'with a single type', vcr: { cassette_name: 'list_spots_with_single_type' } do
       before(:each) do
         @collection = GooglePlaces::Spot.list(@lat, @lng, api_key, @sensor, :radius => @radius, :types => 'cafe')
       end
 
       it 'should have Spots with a specific type' do
         @collection.each do |spot|
-          spot.types.should include('cafe')
+          expect(spot.types).to include('cafe')
         end
       end
     end
 
-    describe 'with multiple types' do
-      use_vcr_cassette 'list_spots_with_multiple_types'
-
+    describe 'with multiple types', vcr: { cassette_name: 'list_spots_with_multiple_types' } do
       before(:each) do
         @collection = GooglePlaces::Spot.list(@lat, @lng, api_key, @sensor, :radius => @radius, :types => ['food','establishment'])
       end
 
       it 'should have Spots with specific types' do
         @collection.each do |spot|
-          (spot.types & ['food', 'establishment']).should be_any
+          expect(spot.types & ['food', 'establishment']).to be_any
         end
       end
     end
 
-    describe 'searching by name' do
-      use_vcr_cassette 'list_spots_with_name'
-
+    describe 'searching by name', vcr: { cassette_name: 'list_spots_with_name' } do
       before(:each) do
         @collection = GooglePlaces::Spot.list(@lat, @lng, api_key, @sensor, :radius => @radius, :name => 'italian')
       end
@@ -69,8 +62,7 @@ describe GooglePlaces::Spot do
       end
     end
 
-    describe 'searching by name and types' do
-      use_vcr_cassette 'list_spots_with_name_and_types'
+    describe 'searching by name and types', vcr: { cassette_name: 'list_spots_with_name_and_types' } do
 
       before(:each) do
         @collection = GooglePlaces::Spot.list(@lat, @lng, api_key, @sensor, :radius => @radius, :types => ['food','establishment'], :name => 'italian')
@@ -89,19 +81,18 @@ describe GooglePlaces::Spot do
 
       it 'should have Spots with specific types' do
         @collection.each do |spot|
-          (spot.types & ['food', 'establishment']).should be_any
+          expect(spot.types & ['food', 'establishment']).to be_any
         end
       end
     end
 
-    describe 'searching by types with exclusion' do
-      use_vcr_cassette 'list_spots_with_types_and_exclusion'
+    describe 'searching by types with exclusion', vcr: { cassette_name: 'list_spots_with_types_and_exclusion' } do
 
       it 'should exclude spots with type "restaurant"' do
         @collection = GooglePlaces::Spot.list(@lat, @lng, api_key, @sensor, :radius => @radius, :types => ['food','establishment'], :exclude => 'restaurant')
 
         @collection.map(&:types).each do |types|
-          types.should_not include('restaurant')
+          expect(types).to_not include('restaurant')
         end
       end
 
@@ -109,23 +100,20 @@ describe GooglePlaces::Spot do
         @collection = GooglePlaces::Spot.list(@lat, @lng, api_key, @sensor, :radius => @radius, :types => ['food','establishment'], :exclude => ['restaurant', 'cafe'])
 
         @collection.map(&:types).each do |types|
-          types.should_not include('restaurant')
-          types.should_not include('cafe')
+          expect(types).to_not include('restaurant')
+          expect(types).to_not include('cafe')
         end
       end
     end
 
-    describe 'working with premium data' do
-      use_vcr_cassette 'premium_list_spots_with_data'
+    describe 'working with premium data', vcr: { cassette_name: 'premium_list_spots_with_data' } do
 
       it 'should return data with zagat_selected flag only' do
         # hardcoded coordinates & options to get non-zero results count
         @collection = GooglePlaces::Spot.list('39.60049820', '-106.52202606', 'DUMMY_KEY', @sensor, :radius => @radius, :zagat_selected => true, :types => ['restaurant','cafe'], :radius => 20000)
 
-        @collection.map(&:zagat_selected).uniq.should eq [true]
-
-
-        @collection.map(&:zagat_reviewed).uniq.should eq [true]
+        expect(@collection.map(&:zagat_selected).uniq).to eq([true])
+        expect(@collection.map(&:zagat_reviewed).uniq).to eq([true])
       end
 
       it 'should return data with zagat_selected flag only' do
@@ -134,32 +122,31 @@ describe GooglePlaces::Spot do
 
         item = @collection.detect {|item| item.zagat_reviewed == true}
         item = GooglePlaces::Spot.find(item.reference, 'DUMMY_KEY', @sensor, :review_summary => true)
-        item.review_summary.should_not eq nil
+        expect(item.review_summary).to_not eq(nil)
       end
     end
   end
 
-  context 'Multiple page request' do
-    use_vcr_cassette 'multiple_page_request'
+  context 'Multiple page request', vcr: { cassette_name: 'multiple_page_request' } do
 
     it 'should return >20 results when :multipage_request is true' do
-      @collection = GooglePlaces::Spot.list_by_query("wolfgang", api_key, @sensor, :lat => "40.808235", :lng => "-73.948733", :radius => @radius, :multipage => true)
+      @collection = GooglePlaces::Spot.list_by_query('wolfgang', api_key, @sensor, :lat => '40.808235', :lng => '-73.948733', :radius => @radius, :multipage => true)
       @collection.should have_at_least(21).places
     end
 
     it 'should return at most 20 results when :multipage is false' do
-      @collection = GooglePlaces::Spot.list_by_query("wolfgang", api_key, @sensor, :lat => "40.808235", :lng => "-73.948733", :radius => @radius, :multipage => false)
+      @collection = GooglePlaces::Spot.list_by_query('wolfgang', api_key, @sensor, :lat => '40.808235', :lng => '-73.948733', :radius => @radius, :multipage => false)
       @collection.should have_at_most(20).places
     end
 
     it 'should return at most 20 results when :multipage is not present' do
-      @collection = GooglePlaces::Spot.list_by_query("wolfgang", api_key, @sensor, :lat => "40.808235", :lng => "-73.948733", :radius => @radius)
+      @collection = GooglePlaces::Spot.list_by_query('wolfgang', api_key, @sensor, :lat => '40.808235', :lng => '-73.948733', :radius => @radius)
       @collection.should have_at_most(20).places
     end
 
     it 'should return a pagetoken when there is more than 20 results and :multipage is false' do
-      @collection = GooglePlaces::Spot.list_by_query("wolfgang", api_key, @sensor, :lat => "40.808235", :lng => "-73.948733", :radius => @radius, :multipage => false)
-      @collection.last.nextpagetoken.should_not be_nil
+      @collection = GooglePlaces::Spot.list_by_query('wolfgang', api_key, @sensor, :lat => '40.808235', :lng => '-73.948733', :radius => @radius, :multipage => false)
+      expect(@collection.last.nextpagetoken).to_not be_nil
     end
 
     it 'should return some results when :pagetoken is present' do
@@ -169,24 +156,22 @@ describe GooglePlaces::Spot do
 
   end
 
-  context 'List spots by query' do
-    use_vcr_cassette 'list_spots'
+  context 'List spots by query', vcr: { cassette_name: 'list_spots' } do
 
     after(:each) do
-      @collection.map(&:class).uniq.should == [GooglePlaces::Spot]
+      expect(@collection.map(&:class).uniq).to eq [GooglePlaces::Spot]
     end
 
     it 'should be a collection of Spots' do
-      @collection = GooglePlaces::Spot.list_by_query("Statue of liberty, New York", api_key, @sensor)
+      @collection = GooglePlaces::Spot.list_by_query('Statue of liberty, New York', api_key, @sensor)
     end
 
   end
 
-  context 'List spots by radar' do
-    use_vcr_cassette 'list_spots_by_radar'
+  context 'List spots by radar', vcr: { cassette_name: 'list_spots_by_radar' } do
 
     after(:each) do
-      @collection.map(&:class).uniq.should == [GooglePlaces::Spot]
+      expect(@collection.map(&:class).uniq).to eq [GooglePlaces::Spot]
     end
 
     it 'should be a collection of Spots' do
@@ -195,17 +180,16 @@ describe GooglePlaces::Spot do
 
   end
 
-  context 'Find a single spot' do
-    use_vcr_cassette 'single_spot'
+  context 'Find a single spot', vcr: { cassette_name: 'single_spot' } do
     before :each do
       @spot = GooglePlaces::Spot.find(@reference, api_key, @sensor)
     end
     it 'should be a Spot' do
-      @spot.class.should == GooglePlaces::Spot
+      expect(@spot.class).to eq(GooglePlaces::Spot)
     end
     %w(reference vicinity lat lng name icon types id formatted_phone_number international_phone_number formatted_address address_components street_number street city region postal_code country rating url types website price_level opening_hours events utc_offset).each do |attribute|
       it "should have the attribute: #{attribute}" do
-        @spot.respond_to?(attribute).should == true
+        expect(@spot.respond_to?(attribute)).to eq(true)
       end
 
       it "should respond to ['#{attribute}']" do
@@ -221,7 +205,7 @@ describe GooglePlaces::Spot do
     end
     %w(rating type author_name author_url text time).each do |attribute|
       it "should have the review attribute: #{attribute}" do
-        @spot.reviews[0].respond_to?(attribute).should be true
+        expect(@spot.reviews[0].respond_to?(attribute)).to eq(true)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,12 +2,8 @@ require 'rubygems'
 require 'bundler/setup'
 require 'vcr_setup'
 require 'api_key'
-require File.dirname(__FILE__) + "/../lib/" + 'google_places'
+require File.dirname(__FILE__) + '/../lib/' + 'google_places'
 
 def api_key
   RSPEC_API_KEY
-end
-
-RSpec.configure do |config|
-  config.extend VCR::RSpec::Macros
 end

--- a/spec/vcr_setup.rb
+++ b/spec/vcr_setup.rb
@@ -2,7 +2,8 @@ require 'vcr'
 
 VCR.configure do |c|
   c.cassette_library_dir     = 'spec/vcr_cassettes'
-  c.hook_into                  :fakeweb
+  c.hook_into                  :webmock
   c.ignore_localhost         = true
   c.default_cassette_options = { :record => :new_episodes }
+  c.configure_rspec_metadata!
 end


### PR DESCRIPTION
- Update VCR and remove deprecated methods in favor of new ones (see: https://gist.github.com/kincorvia/4540489).
- Configure VCR to hook_into :webmock since :fakeweb has been deprecated.
- RSpec :should was deprecated, change to :expect
- Remove tests expecting RequestDeniedError raised when the :sensor parameter is not supplied as this is no longer the case.

Also, some general cleanup:
- double quotes to single quotes
