### PR TITLE
Change reference to place_id for single Spot fetch

### DIFF
--- a/lib/google_places/client.rb
+++ b/lib/google_places/client.rb
@@ -103,7 +103,7 @@ module GooglePlaces
     # Search for a Spot with a reference key
     #
     # @return [Spot]
-    # @param [String] reference the reference of the spot
+    # @param [String] place_id the place_id of the spot
     # @param [Hash] options
     # @option options [Boolean] :sensor (false)
     #   Indicates whether or not the Place request came from a device using a location sensor (e.g. a GPS) to determine the location sent in this request.
@@ -116,8 +116,8 @@ module GooglePlaces
     # @option options [Object] :retry_options[:status] ([])
     # @option options [Integer] :retry_options[:max] (0) the maximum retries
     # @option options [Integer] :retry_options[:delay] (5) the delay between each retry in seconds
-    def spot(reference, options = {})
-      Spot.find(reference, @api_key, @sensor, @options.merge(options))
+    def spot(place_id, options = {})
+      Spot.find(place_id, @api_key, @sensor, @options.merge(options))
     end
 
     # Search for Spots with a query

--- a/lib/google_places/request.rb
+++ b/lib/google_places/request.rb
@@ -60,15 +60,17 @@ module GooglePlaces
       request.parsed_response
     end
 
-    # Search for a Spot with a reference key
+    # Search for a Spot with a place_id key
     #
     # @return [Spot]
     # @param [Hash] options
     # @option options [String] :key
     #   the provided api key.
     #   <b>Note that this is a mandatory parameter</b>
-    # @option options [String] :reference
-    #   The reference of a already retrieved Spot
+    # @option options [String] :place_id
+    #   The place_id of the Spot. This parameter should be sent as placeid
+    #   in requests but is snake_cased in responses (place_id)
+    #   @see: https://developers.google.com/places/documentation/details
     #   <b>Note that this is a mandatory parameter</b>
     # @option options [Boolean] :sensor
     #   Indicates whether or not the Place request came from a device using a location sensor (e.g. a GPS) to determine the location sent in this request.

--- a/lib/google_places/spot.rb
+++ b/lib/google_places/spot.rb
@@ -173,7 +173,7 @@ module GooglePlaces
     # Search for a Spot with a reference key
     #
     # @return [Spot]
-    # @param [String] reference the reference of the spot
+    # @param [String] place_id the place_id of the spot
     # @param [String] api_key the provided api key
     # @param [Boolean] sensor
     #   Indicates whether or not the Place request came from a device using a location sensor (e.g. a GPS)
@@ -188,13 +188,13 @@ module GooglePlaces
     # @option options [Object] :retry_options[:status] ([])
     # @option options [Integer] :retry_options[:max] (0) the maximum retries
     # @option options [Integer] :retry_options[:delay] (5) the delay between each retry in seconds
-    def self.find(reference, api_key, sensor, options = {})
+    def self.find(place_id, api_key, sensor, options = {})
       language  = options.delete(:language)
       retry_options = options.delete(:retry_options) || {}
       extensions = options.delete(:review_summary) ? 'review_summary' : nil
 
       response = Request.spot(
-        :reference => reference,
+        :placeid => place_id,
         :sensor => sensor,
         :key => api_key,
         :language => language,

--- a/spec/google_places/client_spec.rb
+++ b/spec/google_places/client_spec.rb
@@ -15,12 +15,12 @@ describe GooglePlaces::Client do
     @client.spots(lat, lng)
   end
 
-  it 'should request a single spot' do
-    reference = 'CoQBeAAAAO-prCRp9Atcj_rvavsLyv-DnxbGkw8QyRZb6Srm6QHOcww6lqFhIs2c7Ie6fMg3PZ4PhicfJL7ZWlaHaLDTqmRisoTQQUn61WTcSXAAiCOzcm0JDBnafqrskSpFtNUgzGAOx29WGnWSP44jmjtioIsJN9ik8yjK7UxP4buAmMPVEhBXPiCfHXk1CQ6XRuQhpztsGhQU4U6-tWjTHcLSVzjbNxoiuihbaA'
+  it 'should request a single spot by place_id' do
+    place_id = 'ChIJu46S-ZZhLxMROG5lkwZ3D7k'
     @client = GooglePlaces::Client.new(api_key)
-    expect(GooglePlaces::Spot).to receive(:find).with(reference, api_key, false, {})
+    expect(GooglePlaces::Spot).to receive(:find).with(place_id, api_key, false, {})
 
-    @client.spot(reference)
+    @client.spot(place_id)
   end
 
   it 'should request spots by query' do

--- a/spec/google_places/spot_spec.rb
+++ b/spec/google_places/spot_spec.rb
@@ -7,8 +7,8 @@ describe GooglePlaces::Spot do
     @lng = '151.1957362'
     @radius = 200
     @sensor = false
-    @reference = 'CnRsAAAASc4grenwL0h3X5VPNp5fkDNfqbjt3iQtWIPlKS-3ms9GbnCxR_FLHO0B0ZKCgJSg19qymkeHagjQFB4aUL87yhp4mhFTc17DopK1oiYDaeGthztSjERic8TmFNe-6zOpKSdiZWKE6xlQvcbSiWIJchIQOEYZqunSSZqNDoBSs77bWRoUJcMMVANtSlhy0llKI0MI6VcC7DU'
     @pagetoken = 'CmRVAAAAqKK43TjXKnyEx4-XTWd4bC-iBq88Olspwga_JQbEpznYpfwXYbWBrxmb-1QYD4DMtq8gym5YruCEVjByOlKn8PWKQO5fHvuYD8rWKHUeBvMleM7k3oh9TUG8zqcyuhPmEhCG_C2XuypmkQ20hRvxro4sGhQN3nbWCjgpjyG_E_ayjVIoTGbViw'
+    @place_id = 'ChIJN1t_tDeuEmsRUsoyG83frY4'
   end
 
   context 'List spots', vcr: { cassette_name: 'list_spots' } do
@@ -134,7 +134,7 @@ describe GooglePlaces::Spot do
 
   context 'Find a single spot', vcr: { cassette_name: 'single_spot' } do
     before :each do
-      @spot = GooglePlaces::Spot.find(@reference, api_key, @sensor)
+      @spot = GooglePlaces::Spot.find(@place_id, api_key, @sensor)
     end
     it 'should be a Spot' do
       expect(@spot.class).to eq(GooglePlaces::Spot)


### PR DESCRIPTION
"The id and reference fields are deprecated as of June 24, 2014"
According to the [documentation](https://developers.google.com/places/documentation/search) the id and reference keys are going to be removed. Spot.find method should use the place_id to fetch a Spot instead of the reference.

Since many developers may still count on reference and id (if that's what they store in their database for example), it is not a good option to completely remove the support for reference. Whatever the solution will be, the place_id will be the default so changes will be needed to make it work with reference key. 
