### PR TITLE
Upgrade safe_yaml and httparty gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.1.3
+  - 2.3.1
 script: bundle exec rspec
 before_script: cp spec/api_key.travis.rb spec/api_key.rb
 after_script: rm spec/api_key.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.1.3
+  - 2.2.5
   - 2.3.1
 script: bundle exec rspec
 before_script: cp spec/api_key.travis.rb spec/api_key.rb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     google_places (0.32.0)
-      httparty (~> 0.13.1)
+      httparty (>= 0.13.1, < 0.14.1)
 
 GEM
   remote: http://rubygems.org/
@@ -11,10 +11,8 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
-    httparty (0.13.3)
-      json (~> 1.8)
+    httparty (0.14.0)
       multi_xml (>= 0.5.2)
-    json (1.8.2)
     multi_xml (0.5.5)
     rspec (3.0.0)
       rspec-core (~> 3.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ GEM
     rspec-mocks (3.0.2)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.2)
-    safe_yaml (1.0.3)
+    safe_yaml (1.0.4)
     vcr (2.9.2)
     webmock (1.18.0)
       addressable (>= 2.3.6)
@@ -42,3 +42,6 @@ DEPENDENCIES
   rspec (~> 3.0.0)
   vcr (~> 2.9.2)
   webmock (~> 1.18.0)
+
+BUNDLED WITH
+   1.12.4

--- a/google_places.gemspec
+++ b/google_places.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_dependency 'httparty',            '~> 0.13.1'
+  s.add_dependency 'httparty',            '>= 0.13.1', '< 0.14.1'
   s.add_development_dependency 'rspec',   '~> 3.0.0'
   s.add_development_dependency 'webmock', '~> 1.18.0'
   s.add_development_dependency 'vcr',     '~> 2.9.2'


### PR DESCRIPTION
Running specs with Ruby 2.3.1, safe_yaml 1.0.3 doesn't seem to work, and their GitHub page recommends upgrading to 1.0.4.

Upgraded httparty to 0.14.0 as this includes support for JSON v2.0

Finally, added Ruby 2.3.1 to the travis config so specs are being run against the latest stable Ruby version.