### PR TITLE
v0.33.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ script: bundle exec rspec
 before_script: cp spec/api_key.travis.rb spec/api_key.rb
 after_script: rm spec/api_key.rb
 before_install:
-  - gem install bundler -v 1.13.2
+  - gem install bundler -v 1.14.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,45 +1,49 @@
 PATH
   remote: .
   specs:
-    google_places (0.32.0)
+    google_places (0.33.0)
       httparty (>= 0.13.1, < 0.14.1)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    addressable (2.3.6)
-    crack (0.4.2)
+    addressable (2.4.0)
+    crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    diff-lcs (1.2.5)
+    diff-lcs (1.3)
+    hashdiff (0.3.2)
     httparty (0.14.0)
       multi_xml (>= 0.5.2)
-    multi_xml (0.5.5)
-    rspec (3.0.0)
-      rspec-core (~> 3.0.0)
-      rspec-expectations (~> 3.0.0)
-      rspec-mocks (~> 3.0.0)
-    rspec-core (3.0.2)
-      rspec-support (~> 3.0.0)
-    rspec-expectations (3.0.2)
+    multi_xml (0.6.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.0.0)
-    rspec-mocks (3.0.2)
-      rspec-support (~> 3.0.0)
-    rspec-support (3.0.2)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
     safe_yaml (1.0.4)
     vcr (2.9.3)
-    webmock (1.18.0)
+    webmock (1.24.6)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  addressable (~> 2.4.0)
   google_places!
-  rspec (~> 3.0.0)
-  vcr (~> 2.9.3)
-  webmock (~> 1.18.0)
+  rspec (~> 3.0)
+  vcr (~> 2.9)
+  webmock (~> 1.18)
 
 BUNDLED WITH
-   1.12.5
+   1.14.4

--- a/README.rdoc
+++ b/README.rdoc
@@ -87,7 +87,7 @@ Get results in specific language:
 
   @client.spots(-33.8670522, 151.1957362, :language => 'en')
 
-Get detailed spots(This makes an extra call for each spot and returns a collection of the detailed spots.):
+Get detailed spots (this makes an extra call for each spot and returns a collection of the detailed spots):
 
   @client.spots(-33.8670522, 151.1957362, :detail => true)
 

--- a/google_places.gemspec
+++ b/google_places.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'google_places'
-  s.version     = '0.32.0'
+  s.version     = '0.33.0'
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Marcel de Graaf']
   s.email       = ['mail@marceldegraaf.net']

--- a/google_places.gemspec
+++ b/google_places.gemspec
@@ -17,8 +17,9 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_dependency 'httparty',            '>= 0.13.1', '< 0.14.1'
-  s.add_development_dependency 'rspec',   '~> 3.0.0'
-  s.add_development_dependency 'webmock', '~> 1.18.0'
-  s.add_development_dependency 'vcr',     '~> 2.9.3'
+  s.add_dependency 'httparty',                ['>= 0.13.1', '< 0.14.1']
+  s.add_development_dependency 'rspec',       '~> 3.0'
+  s.add_development_dependency 'addressable', '~> 2.4.0'
+  s.add_development_dependency 'webmock',     '~> 1.18'
+  s.add_development_dependency 'vcr',         '~> 2.9'
 end


### PR DESCRIPTION
New version for Rubygems with all previous fixes + new features since 0.32.0

* Fixed Travis specs, including adding more versions of Ruby to test against
* Upgrade gems
* Added new option to the spots method to return detailed results