### PR TITLE
Ensure HTTP 5xx errors are handled gracefully

### DIFF
--- a/lib/google_places/error.rb
+++ b/lib/google_places/error.rb
@@ -34,4 +34,12 @@ module GooglePlaces
 
   class NotFoundError < HTTParty::ResponseError
   end
+
+  # Thrown when the server returns any 5xx error
+  #
+  # This can be the case when:
+  # - There is a network problem between this gem and Google's API servers
+  # - Google's API is broken
+  class APIConnectionError < HTTParty::ResponseError
+  end
 end

--- a/lib/google_places/request.rb
+++ b/lib/google_places/request.rb
@@ -347,7 +347,8 @@ module GooglePlaces
     # @raise [NotFoundError] when server response object includes 'NOT_FOUND'
     # @return [String] the response from the server as JSON
     def parsed_response
-      return @response.headers["location"] if @response.code >= 300 and @response.code < 400
+      return @response.headers["location"] if @response.code >= 300 && @response.code < 400
+      raise APIConnectionError.new(@response) if @response.code >= 500 && @response.code < 600
       case @response.parsed_response['status']
       when 'OK', 'ZERO_RESULTS'
         @response.parsed_response
@@ -363,6 +364,5 @@ module GooglePlaces
         raise NotFoundError.new(@response)
       end
     end
-
   end
 end

--- a/spec/google_places/request_spec.rb
+++ b/spec/google_places/request_spec.rb
@@ -291,4 +291,16 @@ describe GooglePlaces::Request do
     end
   end
 
+  context 'with an HTTP 502 response', vcr: { cassette_name: 'http_502' } do
+    it 'correctly handles the exception' do
+      stub_const("GooglePlaces::Request::DETAILS_URL", 'http://httpstat.us/502')
+
+      expect(lambda {
+        GooglePlaces::Request.spot(
+          :reference => @reference,
+          :key => api_key
+        )
+      }).to raise_error GooglePlaces::APIConnectionError
+    end
+  end
 end

--- a/spec/vcr_cassettes/http_502.yml
+++ b/spec/vcr_cassettes/http_502.yml
@@ -2,50 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://httpstat.us/500?key=&reference=CnRsAAAASc4grenwL0h3X5VPNp5fkDNfqbjt3iQtWIPlKS-3ms9GbnCxR_FLHO0B0ZKCgJSg19qymkeHagjQFB4aUL87yhp4mhFTc17DopK1oiYDaeGthztSjERic8TmFNe-6zOpKSdiZWKE6xlQvcbSiWIJchIQOEYZqunSSZqNDoBSs77bWRoUJcMMVANtSlhy0llKI0MI6VcC7DU
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 500
-      message: Internal Server Error
-    headers:
-      Cache-Control:
-      - private
-      Content-Length:
-      - '25'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Server:
-      - Microsoft-IIS/8.0
-      X-Aspnetmvc-Version:
-      - '5.1'
-      Access-Control-Allow-Origin:
-      - "*"
-      X-Aspnet-Version:
-      - 4.0.30319
-      X-Powered-By:
-      - ASP.NET
-      Set-Cookie:
-      - ARRAffinity=5f087fd6a40a6d05f0b0eb568d99070a0e7b27a443c43c64047aae88fa2e0bea;Path=/;HttpOnly;Domain=httpstat.us
-      Date:
-      - Tue, 07 Nov 2017 10:12:43 GMT
-    body:
-      encoding: UTF-8
-      string: 500 Internal Server Error
-    http_version: 
-  recorded_at: Tue, 07 Nov 2017 10:12:43 GMT
-- request:
-    method: get
-    uri: http://httpstat.us/502?key=&reference=CnRsAAAASc4grenwL0h3X5VPNp5fkDNfqbjt3iQtWIPlKS-3ms9GbnCxR_FLHO0B0ZKCgJSg19qymkeHagjQFB4aUL87yhp4mhFTc17DopK1oiYDaeGthztSjERic8TmFNe-6zOpKSdiZWKE6xlQvcbSiWIJchIQOEYZqunSSZqNDoBSs77bWRoUJcMMVANtSlhy0llKI0MI6VcC7DU
+    uri: http://httpstat.us/502?key=AIzaSyAKeN0XMV5LqJmqBrZZ1K8qMipFW7-Eybg&reference=CnRsAAAASc4grenwL0h3X5VPNp5fkDNfqbjt3iQtWIPlKS-3ms9GbnCxR_FLHO0B0ZKCgJSg19qymkeHagjQFB4aUL87yhp4mhFTc17DopK1oiYDaeGthztSjERic8TmFNe-6zOpKSdiZWKE6xlQvcbSiWIJchIQOEYZqunSSZqNDoBSs77bWRoUJcMMVANtSlhy0llKI0MI6VcC7DU
     body:
       encoding: US-ASCII
       string: ''
@@ -80,10 +37,10 @@ http_interactions:
       Set-Cookie:
       - ARRAffinity=5f087fd6a40a6d05f0b0eb568d99070a0e7b27a443c43c64047aae88fa2e0bea;Path=/;HttpOnly;Domain=httpstat.us
       Date:
-      - Tue, 07 Nov 2017 10:20:57 GMT
+      - Tue, 07 Nov 2017 10:30:02 GMT
     body:
       encoding: UTF-8
       string: 502 Bad Gateway
     http_version: 
-  recorded_at: Tue, 07 Nov 2017 10:20:57 GMT
+  recorded_at: Tue, 07 Nov 2017 10:30:03 GMT
 recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/http_502.yml
+++ b/spec/vcr_cassettes/http_502.yml
@@ -1,0 +1,89 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://httpstat.us/500?key=&reference=CnRsAAAASc4grenwL0h3X5VPNp5fkDNfqbjt3iQtWIPlKS-3ms9GbnCxR_FLHO0B0ZKCgJSg19qymkeHagjQFB4aUL87yhp4mhFTc17DopK1oiYDaeGthztSjERic8TmFNe-6zOpKSdiZWKE6xlQvcbSiWIJchIQOEYZqunSSZqNDoBSs77bWRoUJcMMVANtSlhy0llKI0MI6VcC7DU
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '25'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.0
+      X-Aspnetmvc-Version:
+      - '5.1'
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Set-Cookie:
+      - ARRAffinity=5f087fd6a40a6d05f0b0eb568d99070a0e7b27a443c43c64047aae88fa2e0bea;Path=/;HttpOnly;Domain=httpstat.us
+      Date:
+      - Tue, 07 Nov 2017 10:12:43 GMT
+    body:
+      encoding: UTF-8
+      string: 500 Internal Server Error
+    http_version: 
+  recorded_at: Tue, 07 Nov 2017 10:12:43 GMT
+- request:
+    method: get
+    uri: http://httpstat.us/502?key=&reference=CnRsAAAASc4grenwL0h3X5VPNp5fkDNfqbjt3iQtWIPlKS-3ms9GbnCxR_FLHO0B0ZKCgJSg19qymkeHagjQFB4aUL87yhp4mhFTc17DopK1oiYDaeGthztSjERic8TmFNe-6zOpKSdiZWKE6xlQvcbSiWIJchIQOEYZqunSSZqNDoBSs77bWRoUJcMMVANtSlhy0llKI0MI6VcC7DU
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 502
+      message: Bad Gateway
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '15'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.0
+      X-Aspnetmvc-Version:
+      - '5.1'
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Set-Cookie:
+      - ARRAffinity=5f087fd6a40a6d05f0b0eb568d99070a0e7b27a443c43c64047aae88fa2e0bea;Path=/;HttpOnly;Domain=httpstat.us
+      Date:
+      - Tue, 07 Nov 2017 10:20:57 GMT
+    body:
+      encoding: UTF-8
+      string: 502 Bad Gateway
+    http_version: 
+  recorded_at: Tue, 07 Nov 2017 10:20:57 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
Previously an HTTP 5xx error from the Google API resulted in a JSON::ParserError exception being raised.

This change ensures that any 5xx error returns a GooglePlaces::APIConnectionError.