### PR TITLE
Client: fix spots* methods options leaking to other methods

### DIFF
--- a/lib/google_places/client.rb
+++ b/lib/google_places/client.rb
@@ -93,9 +93,10 @@ module GooglePlaces
     # @see http://spreadsheets.google.com/pub?key=p9pdwsai2hDMsLkXsoM05KQ&gid=1 List of supported languages
     # @see https://developers.google.com/maps/documentation/places/supported_types List of supported types
     def spots(lat, lng, options = {})
-      detail = @options.merge!(options).delete(:detail)
+      options = @options.merge(options)
+      detail = options.delete(:detail)
       collection_detail_level(
-        Spot.list(lat, lng, @api_key, @options),
+        Spot.list(lat, lng, @api_key, options),
         detail
       )
     end
@@ -157,9 +158,10 @@ module GooglePlaces
     # @see http://spreadsheets.google.com/pub?key=p9pdwsai2hDMsLkXsoM05KQ&gid=1 List of supported languages
     # @see https://developers.google.com/maps/documentation/places/supported_types List of supported types
     def spots_by_query(query, options = {})
-      detail = @options.merge!(options).delete(:detail)
+      options = @options.merge(options)
+      detail = options.delete(:detail)
       collection_detail_level(
-        Spot.list_by_query(query, @api_key, @options),
+        Spot.list_by_query(query, @api_key, options),
         detail
       )
     end
@@ -200,9 +202,10 @@ module GooglePlaces
     #
     # @see https://developers.google.com/maps/documentation/places/supported_types List of supported types
     def spots_by_bounds(bounds, options = {})
-      detail = @options.merge!(options).delete(:detail)
+      options = @options.merge(options)
+      detail = options.delete(:detail)
       collection_detail_level(
-        Spot.list_by_bounds(bounds, @api_key, @options),
+        Spot.list_by_bounds(bounds, @api_key, options),
         detail
       )
     end
@@ -224,9 +227,10 @@ module GooglePlaces
     #
     # @see https://developers.google.com/maps/documentation/places/supported_types List of supported types
     def spots_by_pagetoken(pagetoken, options = {})
-      detail = @options.merge!(options).delete(:detail)
+      options = @options.merge(options)
+      detail = options.delete(:detail)
       collection_detail_level(
-        Spot.list_by_pagetoken(pagetoken, @api_key, @options),
+        Spot.list_by_pagetoken(pagetoken, @api_key, options),
         detail
       )
     end
@@ -268,9 +272,10 @@ module GooglePlaces
     #
     # @see https://developers.google.com/places/documentation/search#RadarSearchRequests
     def spots_by_radar(lat, lng, options = {})
-      detail = @options.merge!(options).delete(:detail)
+      options = @options.merge(options)
+      detail = options.delete(:detail)
       collection_detail_level(
-        Spot.list_by_radar(lat, lng, @api_key, @options),
+        Spot.list_by_radar(lat, lng, @api_key, options),
         detail
       )
     end

--- a/spec/google_places/client_spec.rb
+++ b/spec/google_places/client_spec.rb
@@ -1,15 +1,30 @@
 require 'spec_helper'
 
 describe GooglePlaces::Client do
-  let(:client) { GooglePlaces::Client.new(api_key) }
+  let(:client) { GooglePlaces::Client.new(api_key, client_options) }
+  let(:client_options) { {} }
   let(:fake_spot) { Object.new }
 
-  before do
-    allow(fake_spot).to receive(:place_id) { 1 }
+  before { allow(fake_spot).to receive(:place_id) { 1 } }
+
+  describe '::api_key' do
+    it 'should initialize with an api_key' do
+      expect(client.api_key).to eq(api_key)
+    end
   end
 
-  it 'should initialize with an api_key' do
-    expect(client.api_key).to eq(api_key)
+  describe '::options' do
+    it 'should initialize without options' do
+      expect(client.options).to eq({})
+    end
+
+    context 'with options' do
+      let(:client_options) { {radius: 1000} }
+
+      it 'should initialize with options' do
+        expect(client.options).to eq(client_options)
+      end
+    end
   end
 
   describe '::spots' do
@@ -33,6 +48,15 @@ describe GooglePlaces::Client do
         client.spots(lat, lng, detail: true)
       end
     end
+
+    context 'with options' do
+      let(:client_options) { {radius: 1000} }
+      let(:method_options) { {radius: 2000} }
+      it 'preserves client options while merging with method options' do
+        allow(GooglePlaces::Spot).to receive(:list).with(lat, lng, api_key, method_options)
+        expect { client.spots(lat, lng, method_options) }.not_to change(client, :options)
+      end
+    end
   end
 
   describe '::spot' do
@@ -41,16 +65,21 @@ describe GooglePlaces::Client do
       expect(GooglePlaces::Spot).to receive(:find).with(place_id, api_key, {})
       client.spot(place_id)
     end
+
+    context 'with options' do
+      let(:client_options) { {language: 'en'} }
+      let(:method_options) { {language: 'es'} }
+      it 'preserves client options while merging with method options' do
+        allow(GooglePlaces::Spot).to receive(:find).with(place_id, api_key, method_options)
+        expect { client.spot(place_id, method_options) }.not_to change(client, :options)
+      end
+    end
   end
 
   describe '::spots_by_query' do
     let(:query) { 'Statue of liberty, New York' }
     it 'should request spots by query' do
-      expect(GooglePlaces::Spot).to receive(:list_by_query).with(
-        query,
-        api_key,
-        {}
-      )
+      expect(GooglePlaces::Spot).to receive(:list_by_query).with(query, api_key, {})
       client.spots_by_query(query)
     end
 
@@ -67,6 +96,15 @@ describe GooglePlaces::Client do
         client.spots_by_query(query, detail: true)
       end
     end
+
+    context 'with options' do
+      let(:client_options) { {language: 'en'} }
+      let(:method_options) { {language: 'es'} }
+      it 'preserves client options while merging with method options' do
+        allow(GooglePlaces::Spot).to receive(:list_by_query).with(query, api_key, method_options)
+        expect { client.spots_by_query(query, method_options) }.not_to change(client, :options)
+      end
+    end
   end
 
   describe '::spots_by_bounds' do
@@ -79,10 +117,7 @@ describe GooglePlaces::Client do
     end
 
     it 'should request spots by bounds' do
-      expect(GooglePlaces::Spot).to receive(:list_by_bounds).with(
-        bounds, api_key,
-        query: query
-      )
+      expect(GooglePlaces::Spot).to receive(:list_by_bounds).with(bounds, api_key, query: query)
       client.spots_by_bounds(bounds, query: query)
     end
 
@@ -99,6 +134,32 @@ describe GooglePlaces::Client do
         client.spots_by_bounds(bounds, query: query, detail: true)
       end
     end
+
+    context 'with options' do
+      let(:client_options) { {language: 'en'} }
+      let(:method_options) { {query: query, language: 'es'} }
+      it 'preserves client options while merging with method options' do
+        allow(GooglePlaces::Spot).to receive(:list_by_bounds).with(bounds, api_key, method_options)
+        expect { client.spots_by_bounds(bounds, method_options) }.not_to change(client, :options)
+      end
+    end
+  end
+
+  describe '::spots_by_pagetoken' do
+    let(:pagetoken) { 'somepagetoken' }
+    it 'should request spots by pagetoken'do
+      expect(GooglePlaces::Spot).to receive(:list_by_pagetoken).with(pagetoken, api_key, {})
+      client.spots_by_pagetoken(pagetoken)
+    end
+
+    context 'with options' do
+      let(:client_options) { {retry_options: {max: 5}} }
+      let(:method_options) { {retry_options: {max: 10}} }
+      it 'preserves client options while merging with method options' do
+        allow(GooglePlaces::Spot).to receive(:list_by_pagetoken).with(pagetoken, api_key, method_options)
+        expect {  client.spots_by_pagetoken(pagetoken, method_options) }.not_to change(client, :options)
+      end
+    end
   end
 
   describe '::spots_by_radar' do
@@ -108,13 +169,7 @@ describe GooglePlaces::Client do
     let(:radius) { 5000 }
 
     it 'should request spots by radar' do
-      expect(GooglePlaces::Spot).to receive(:list_by_radar).with(
-        lat,
-        lng,
-        api_key,
-        radius: radius,
-        keyword: keywords
-      )
+      expect(GooglePlaces::Spot).to receive(:list_by_radar).with(lat, lng, api_key, radius: radius, keyword: keywords)
       client.spots_by_radar(lat, lng, radius: radius, keyword: keywords)
     end
 
@@ -137,18 +192,32 @@ describe GooglePlaces::Client do
         )
       end
     end
+
+    context 'with options' do
+      let(:client_options) { {radius: 1000} }
+      let(:method_options) { {radius: radius, keyword: keywords} }
+      it 'preserves client options while merging with method options' do
+        allow(GooglePlaces::Spot).to receive(:list_by_radar).with(lat, lng, api_key, method_options)
+        expect { client.spots_by_radar(lat, lng, method_options) }.not_to change(client, :options)
+      end
+    end
   end
 
   describe '::predictions_by_input' do
     let(:input) { 'Atlanta' }
 
     it 'should request predictions by input' do
-      expect(GooglePlaces::Prediction).to receive(:list_by_input).with(
-        input,
-        api_key,
-        {}
-      )
+      expect(GooglePlaces::Prediction).to receive(:list_by_input).with(input, api_key, {})
       client.predictions_by_input(input)
+    end
+
+    context 'with options' do
+      let(:client_options) { {radius: 1000} }
+      let(:method_options) { {radius: 2000} }
+      it 'preserves client options while merging with method options' do
+        allow(GooglePlaces::Prediction).to receive(:list_by_input).with(input, api_key, method_options)
+        expect { client.predictions_by_input(input, method_options) }.not_to change(client, :options)
+      end
     end
   end
 


### PR DESCRIPTION
Several methods with options argument had the side effect of
changing the Client instance's `@options` variable. This
caused any option used in a call (e.g. to `my_client.spots`)
to also be used in consecutive calls.