### PR TITLE
expose json_result_object

### DIFF
--- a/lib/google_places/spot.rb
+++ b/lib/google_places/spot.rb
@@ -4,7 +4,8 @@ module GooglePlaces
     attr_accessor :lat, :lng, :viewport, :name, :icon, :reference, :vicinity, :types, :id, :formatted_phone_number,
     :international_phone_number, :formatted_address, :address_components, :street_number, :street, :city, :region,
     :postal_code, :country, :rating, :url, :cid, :website, :reviews, :aspects, :zagat_selected, :zagat_reviewed,
-    :photos, :review_summary, :nextpagetoken, :price_level, :opening_hours, :events, :utc_offset, :place_id, :permanently_closed
+    :photos, :review_summary, :nextpagetoken, :price_level, :opening_hours, :events, :utc_offset, :place_id, :permanently_closed,
+    :json_result_object
 
     # Search for Spots at the provided location
     #
@@ -428,6 +429,7 @@ module GooglePlaces
     # @param [JSON] json_result_object a JSON object to create a Spot from
     # @return [Spot] a newly created spot
     def initialize(json_result_object, api_key)
+      @json_result_object         = json_result_object
       @reference                  = json_result_object['reference']
       @place_id                   = json_result_object['place_id']
       @vicinity                   = json_result_object['vicinity']


### PR DESCRIPTION
Seems to do the trick for: https://github.com/qpowell/google_places/issues/119

```
2.5.3 :007 > res = client.spots_by_query("statue of liberty")
 => #...
2.5.3 :008 > res[0].name
 => "Statue of Liberty National Monument"

2.5.3 :009 > new_spot = GooglePlaces::Spot.new(res[0].json_result_object, ENV['GOOGLE_PLACES_API_KEY'])
 => #...
2.5.3 :010 > new_spot.name
 => "Statue of Liberty National Monument"
```