### PR TITLE
Add business_status property

### DIFF
--- a/lib/google_places/spot.rb
+++ b/lib/google_places/spot.rb
@@ -5,7 +5,7 @@ module GooglePlaces
     :international_phone_number, :formatted_address, :address_components, :street_number, :street, :city, :region,
     :postal_code, :country, :rating, :url, :cid, :website, :reviews, :aspects, :zagat_selected, :zagat_reviewed,
     :photos, :review_summary, :nextpagetoken, :price_level, :opening_hours, :events, :utc_offset, :place_id, :permanently_closed,
-    :json_result_object
+    :json_result_object, :business_status
 
     # Search for Spots at the provided location
     #
@@ -466,6 +466,7 @@ module GooglePlaces
       @events                     = events_component(json_result_object['events'])
       @utc_offset                 = json_result_object['utc_offset']
       @permanently_closed         = json_result_object['permanently_closed']
+      @business_status            = json_result_object['business_status']
     end
 
     def [] (key)

--- a/spec/google_places/spot_spec.rb
+++ b/spec/google_places/spot_spec.rb
@@ -147,7 +147,7 @@ describe GooglePlaces::Spot do
     it 'should be a Spot' do
       expect(@spot.class).to eq(GooglePlaces::Spot)
     end
-    %w(reference vicinity lat lng viewport name icon types id formatted_phone_number international_phone_number formatted_address address_components street_number street city region postal_code country rating url types website price_level opening_hours events utc_offset place_id permanently_closed).each do |attribute|
+    %w(reference vicinity lat lng viewport name icon types id formatted_phone_number international_phone_number formatted_address address_components street_number street city region postal_code country rating url types website price_level opening_hours events utc_offset place_id permanently_closed business_status).each do |attribute|
       it "should have the attribute: #{attribute}" do
         expect(@spot.respond_to?(attribute)).to eq(true)
       end


### PR DESCRIPTION
From Google Places documentation:

"Recommended: Use business_status to get the operational status of businesses, since permanently_closed does not distinguish between temporary and permanent closures."