### PR TITLE
Prediction#list_by_input is more flexible, plus distance_meters

### DIFF
--- a/spec/google_places/prediction_spec.rb
+++ b/spec/google_places/prediction_spec.rb
@@ -19,6 +19,20 @@ describe GooglePlaces::Prediction, vcr: { cassette_name: 'list_predictions'}  do
       GooglePlaces::Prediction.list_by_input('query', api_key, lat: 1, lng: 2, radius: 20)
     end
 
+    it "initiates a request with `location` instead of `lat`/`lng`" do
+      options = request_params(radius: 20, location: "1.00000000,2.00000000")
+      expect(GooglePlaces::Request).to receive(:predictions_by_input).with(options)
+
+      GooglePlaces::Prediction.list_by_input('query', api_key, location: "1.00000000,2.00000000", radius: 20)
+    end
+
+    it "initiates a request with `origin`" do
+      options = request_params(radius: 20, origin: "1.00000000,2.00000000", location: "1.00000000,2.00000000")
+      expect(GooglePlaces::Request).to receive(:predictions_by_input).with(options)
+
+      GooglePlaces::Prediction.list_by_input('query', api_key, origin: "1.00000000,2.00000000", location: "1.00000000,2.00000000", radius: 20)
+    end
+
     it "initiates a request with `types`" do
       options = request_params(types: '(cities)')
       expect(GooglePlaces::Request).to receive(:predictions_by_input).with(options)
@@ -52,6 +66,13 @@ describe GooglePlaces::Prediction, vcr: { cassette_name: 'list_predictions'}  do
       expect(GooglePlaces::Request).to receive(:predictions_by_input).with(options)
 
       GooglePlaces::Prediction.list_by_input('query', api_key, components: 'country:in')
+    end
+
+    it "initiates a request with bonus field `crazy-feature`" do
+      options = request_params('crazy-feature': 'secret-bases')
+      expect(GooglePlaces::Request).to receive(:predictions_by_input).with(options)
+
+      GooglePlaces::Prediction.list_by_input('query', api_key, 'crazy-feature': 'secret-bases')
     end
 
   end


### PR DESCRIPTION
Prediction#list_by_input is more flexible (allows any options); and supports distance_meters field if origin parameter provided

https://developers.google.com/places/web-service/autocomplete#place_autocomplete_results

With `distance_meters`, you can sort the predictions by closeness to the `origin`:

```
# pp client.predictions_by_input("wal", origin: "40.730610,-73.935242", location: "40.730610,-73.935242").sort {|p1, p2| p1.distance_meters.to_i <=> p2.distance_meters.to_i}.map {|p| [p.description, p.distance_meters]}
[["Wall Street, New York, NY, USA", nil],
 ["Waldorf Astoria, Park Avenue, New York, NY, USA", 4262],
 ["Walmart Supercenter, Park Plaza Drive, Secaucus, NJ, USA", 11376],
 ["Walmart Supercenter, 88th Street, North Bergen, NJ, USA", 11379],
 ["Wallington, NJ, USA", 20286]]
```

The `.distance_meters.to_i` was necessary because the "Wall Street" entry was `distance_meters == nil` 🤷 